### PR TITLE
Added an AT to improve timestop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,10 @@ archivesBaseName = 'JoJoBizarreSurvival'
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
 minecraft {
-    mappings channel: 'snapshot', version: '20200619-1.15.1'
+    mappings channel: 'snapshot', version: '20200630-1.15.1'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
-//     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     runs {
         client {

--- a/src/main/java/com/novarch/jojomod/capabilities/timestop/ITimestop.java
+++ b/src/main/java/com/novarch/jojomod/capabilities/timestop/ITimestop.java
@@ -22,6 +22,8 @@ public interface ITimestop {
     void setFuse(int fuse);
     int getFire();
     void setFire(int fire);
+    int getAge();
+    void setAge(int age);
     void putPosX(double posX);
     void putPosY(double posY);
     void putPosZ(double posZ);
@@ -34,6 +36,7 @@ public interface ITimestop {
     void putFallDistance(float fallDistance);
     void putFuse(int fuse);
     void putFire(int fire);
+    void putAge(int age);
     void onDataUpdated();
     void clear();
 }

--- a/src/main/java/com/novarch/jojomod/capabilities/timestop/Timestop.java
+++ b/src/main/java/com/novarch/jojomod/capabilities/timestop/Timestop.java
@@ -35,6 +35,7 @@ public class Timestop implements ITimestop, ICapabilitySerializable<INBT> {
     private float fallDistance = 0;
     private int fuse = 0;
     private int fire = 0;
+    private int age = 0;
 
     @CapabilityInject(ITimestop.class)
     public static final Capability<ITimestop> TIMESTOP = Null();
@@ -152,6 +153,17 @@ public class Timestop implements ITimestop, ICapabilitySerializable<INBT> {
     }
 
     @Override
+    public int getAge() {
+        return age;
+    }
+
+    @Override
+    public void setAge(int age) {
+        this.age = age;
+        onDataUpdated();
+    }
+
+    @Override
     public void putPosX(double posX) {
         this.posX = posX;
     }
@@ -209,6 +221,11 @@ public class Timestop implements ITimestop, ICapabilitySerializable<INBT> {
     @Override
     public void putFire(int fire) {
         this.fire = fire;
+    }
+
+    @Override
+    public void putAge(int age) {
+        this.age = age;
     }
 
     @Override
@@ -275,6 +292,7 @@ public class Timestop implements ITimestop, ICapabilitySerializable<INBT> {
                 nbt.putFloat("fallDistance", instance.getFallDistance());
                 nbt.putInt("fuse", instance.getFuse());
                 nbt.putInt("fire", instance.getFire());
+                nbt.putInt("age", instance.getAge());
                 return nbt;
             }
 
@@ -292,7 +310,7 @@ public class Timestop implements ITimestop, ICapabilitySerializable<INBT> {
                 instance.putRotationYawHead(compoundNBT.getFloat("rotationYawHead"));
                 instance.putFallDistance(compoundNBT.getInt("fallDistance"));
                 instance.putFuse(compoundNBT.getInt("fuse"));
-                instance.putFire(compoundNBT.getInt("fire"));
+                instance.putAge(compoundNBT.getInt("age"));
             }
         }, () -> new Timestop(Null()));
     }

--- a/src/main/java/com/novarch/jojomod/entities/stands/EntityStandBase.java
+++ b/src/main/java/com/novarch/jojomod/entities/stands/EntityStandBase.java
@@ -1,6 +1,5 @@
 package com.novarch.jojomod.entities.stands;
 
-import com.novarch.jojomod.JojoBizarreSurvival;
 import com.novarch.jojomod.capabilities.stand.Stand;
 import com.novarch.jojomod.events.custom.StandEvent;
 import mcp.MethodsReturnNonnullByDefault;
@@ -22,7 +21,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 import net.minecraftforge.fml.network.NetworkHooks;
-import net.minecraftforge.fml.network.PacketDistributor;
 import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/novarch/jojomod/entities/stands/starPlatinum/EntityStarPlatinum.java
+++ b/src/main/java/com/novarch/jojomod/entities/stands/starPlatinum/EntityStarPlatinum.java
@@ -19,6 +19,7 @@ import net.minecraft.entity.IProjectile;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.item.TNTEntity;
+import net.minecraft.entity.item.minecart.TNTMinecartEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.DamagingProjectileEntity;
 import net.minecraft.potion.EffectInstance;
@@ -127,6 +128,10 @@ public class EntityStarPlatinum extends EntityStandBase {
 											props.setFire(entity.getFireTimer());
 											if (entity instanceof TNTEntity)
 												props.setFuse(((TNTEntity) entity).getFuse());
+											if (entity instanceof TNTMinecartEntity)
+												props.setFuse(((TNTMinecartEntity) entity).minecartTNTFuse);
+											if (entity instanceof ItemEntity)
+												props.setAge(((ItemEntity) entity).age);
 										});
 									} else {
 										Timestop.getLazyOptional(entity).ifPresent(props -> {
@@ -139,14 +144,18 @@ public class EntityStarPlatinum extends EntityStandBase {
 													entity.rotationPitch = props.getRotationPitch();
 													entity.setRotationYawHead(props.getRotationYawHead());
 												}
-												if(entity instanceof PlayerEntity)
-													((PlayerEntity)entity).addPotionEffect(new EffectInstance(Effects.SLOWNESS, 50, 255, false, false));
+												if (entity instanceof PlayerEntity)
+													((PlayerEntity) entity).addPotionEffect(new EffectInstance(Effects.SLOWNESS, 50, 255, false, false));
 												entity.setMotion(0, 0, 0);
 
 												entity.fallDistance = props.getFallDistance();
 												entity.setFireTimer(props.getFire());
 												if (entity instanceof TNTEntity)
 													((TNTEntity) entity).setFuse(props.getFuse());
+												if (entity instanceof TNTMinecartEntity)
+													((TNTMinecartEntity) entity).minecartTNTFuse = props.getFuse();
+												if (entity instanceof ItemEntity)
+													((ItemEntity) entity).age = props.getAge();
 												entity.velocityChanged = true;
 											} else {
 												props.setPosition(entity.getPosX(), entity.getPosY(), entity.getPosZ());
@@ -156,6 +165,10 @@ public class EntityStarPlatinum extends EntityStandBase {
 												props.setFire(entity.getFireTimer());
 												if (entity instanceof TNTEntity)
 													props.setFuse(((TNTEntity) entity).getFuse());
+												if (entity instanceof TNTMinecartEntity)
+													props.setFuse(((TNTMinecartEntity) entity).minecartTNTFuse);
+												if (entity instanceof ItemEntity)
+													props.setAge(((ItemEntity) entity).age);
 											}
 										});
 									}
@@ -177,8 +190,8 @@ public class EntityStarPlatinum extends EntityStandBase {
 										if (props.getMotionX() != 0 && props.getMotionY() != 0 && props.getMotionZ() != 0)
 											entity.setMotion(props.getMotionX(), props.getMotionY(), props.getMotionZ());
 									}
-									if(entity instanceof PlayerEntity)
-										((PlayerEntity)entity).removePotionEffect(Effects.SLOWNESS);
+									if (entity instanceof PlayerEntity)
+										((PlayerEntity) entity).removePotionEffect(Effects.SLOWNESS);
 									if (entity instanceof MobEntity)
 										((MobEntity) entity).setNoAI(false);
 									entity.velocityChanged = true;
@@ -288,8 +301,8 @@ public class EntityStarPlatinum extends EntityStandBase {
 									if (props2.getMotionX() != 0 && props2.getMotionY() != 0 && props2.getMotionZ() != 0)
 										entity.setMotion(props2.getMotionX(), props2.getMotionY(), props2.getMotionZ());
 								}
-								if(entity instanceof PlayerEntity)
-									((PlayerEntity)entity).removePotionEffect(Effects.SLOWNESS);
+								if (entity instanceof PlayerEntity)
+									((PlayerEntity) entity).removePotionEffect(Effects.SLOWNESS);
 								if (entity instanceof MobEntity)
 									((MobEntity) entity).setNoAI(false);
 								entity.setMotion(props2.getMotionX(), props2.getMotionY(), props2.getMotionZ());

--- a/src/main/java/com/novarch/jojomod/entities/stands/starPlatinum/RenderStarPlatinumPunch.java
+++ b/src/main/java/com/novarch/jojomod/entities/stands/starPlatinum/RenderStarPlatinumPunch.java
@@ -34,7 +34,13 @@ public class RenderStarPlatinumPunch extends EntityRenderer<EntityStandPunch.Sta
 
 	public void renderEntityModel(@Nonnull EntityStandPunch.StarPlatinum entityIn, MatrixStack matrixStackIn, IRenderTypeBuffer bufferIn, int packedLightIn)
 	{
-		renderManager.textureManager.bindTexture(texture);
+//		renderManager.textureManager.bindTexture(texture);
+//		matrixStackIn.push();
+//		matrixStackIn.translate(entityIn.getPosX(), entityIn.getPosY(), entityIn.getPosZ());
+//		matrixStackIn.scale(2.0f, 2.0f, 2.0f);
+//		punch.render(matrixStackIn, bufferIn.getBuffer(RenderType.getEntitySmoothCutout(getEntityTexture(entityIn))), packedLightIn, 0);
+//		Minecraft.getInstance().textureManager.bindTexture(texture);
+//		matrixStackIn.pop();
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float) entityIn.getPosX(), (float) entityIn.getPosY(), (float) entityIn.getPosZ());
 		GL11.glRotatef(entityIn.prevRotationYaw + (entityIn.rotationYaw - entityIn.prevRotationYaw) * packedLightIn - 90.0F, 0.0F, 1.0F, 0.0F);

--- a/src/main/java/com/novarch/jojomod/entities/stands/theWorld/EntityTheWorld.java
+++ b/src/main/java/com/novarch/jojomod/entities/stands/theWorld/EntityTheWorld.java
@@ -128,6 +128,8 @@ public class EntityTheWorld extends EntityStandBase {
 											props.setFire(entity.getFireTimer());
 											if (entity instanceof TNTEntity)
 												props.setFuse(((TNTEntity) entity).getFuse());
+											if(entity instanceof ItemEntity)
+												props.setAge(((ItemEntity)entity).getAge());
 										});
 									} else {
 										Timestop.getLazyOptional(entity).ifPresent(props -> {
@@ -147,6 +149,8 @@ public class EntityTheWorld extends EntityStandBase {
 												entity.setFireTimer(props.getFire());
 												if (entity instanceof TNTEntity)
 													((TNTEntity) entity).setFuse(props.getFuse());
+												if(entity instanceof ItemEntity)
+													((ItemEntity)entity).age = props.getAge();
 												entity.velocityChanged = true;
 											} else {
 												props.setPosition(entity.getPosX(), entity.getPosY(), entity.getPosZ());
@@ -156,6 +160,8 @@ public class EntityTheWorld extends EntityStandBase {
 												props.setFire(entity.getFireTimer());
 												if (entity instanceof TNTEntity)
 													props.setFuse(((TNTEntity) entity).getFuse());
+												if(entity instanceof ItemEntity)
+													props.setAge(((ItemEntity)entity).getAge());
 											}
 										});
 									}

--- a/src/main/java/com/novarch/jojomod/entities/stands/theWorld/EntityTheWorld.java
+++ b/src/main/java/com/novarch/jojomod/entities/stands/theWorld/EntityTheWorld.java
@@ -19,6 +19,7 @@ import net.minecraft.entity.IProjectile;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.item.TNTEntity;
+import net.minecraft.entity.item.minecart.TNTMinecartEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.DamagingProjectileEntity;
 import net.minecraft.potion.EffectInstance;
@@ -128,8 +129,10 @@ public class EntityTheWorld extends EntityStandBase {
 											props.setFire(entity.getFireTimer());
 											if (entity instanceof TNTEntity)
 												props.setFuse(((TNTEntity) entity).getFuse());
-											if(entity instanceof ItemEntity)
-												props.setAge(((ItemEntity)entity).getAge());
+											if (entity instanceof TNTMinecartEntity)
+												props.setFuse(((TNTMinecartEntity) entity).minecartTNTFuse);
+											if (entity instanceof ItemEntity)
+												props.setAge(((ItemEntity) entity).age);
 										});
 									} else {
 										Timestop.getLazyOptional(entity).ifPresent(props -> {
@@ -142,15 +145,17 @@ public class EntityTheWorld extends EntityStandBase {
 													entity.rotationPitch = props.getRotationPitch();
 													entity.setRotationYawHead(props.getRotationYawHead());
 												}
-												if(entity instanceof PlayerEntity)
-													((PlayerEntity)entity).addPotionEffect(new EffectInstance(Effects.SLOWNESS, 50, 255, false, false));
+												if (entity instanceof PlayerEntity)
+													((PlayerEntity) entity).addPotionEffect(new EffectInstance(Effects.SLOWNESS, 50, 255, false, false));
 												entity.setMotion(0, 0, 0);
 												entity.fallDistance = props.getFallDistance();
 												entity.setFireTimer(props.getFire());
 												if (entity instanceof TNTEntity)
 													((TNTEntity) entity).setFuse(props.getFuse());
-												if(entity instanceof ItemEntity)
-													((ItemEntity)entity).age = props.getAge();
+												if (entity instanceof TNTMinecartEntity)
+													((TNTMinecartEntity) entity).minecartTNTFuse = props.getFuse();
+												if (entity instanceof ItemEntity)
+													((ItemEntity) entity).age = props.getAge();
 												entity.velocityChanged = true;
 											} else {
 												props.setPosition(entity.getPosX(), entity.getPosY(), entity.getPosZ());
@@ -160,8 +165,10 @@ public class EntityTheWorld extends EntityStandBase {
 												props.setFire(entity.getFireTimer());
 												if (entity instanceof TNTEntity)
 													props.setFuse(((TNTEntity) entity).getFuse());
-												if(entity instanceof ItemEntity)
-													props.setAge(((ItemEntity)entity).getAge());
+												if (entity instanceof TNTMinecartEntity)
+													props.setFuse(((TNTMinecartEntity) entity).minecartTNTFuse);
+												if (entity instanceof ItemEntity)
+													props.setAge(((ItemEntity) entity).age);
 											}
 										});
 									}
@@ -183,8 +190,8 @@ public class EntityTheWorld extends EntityStandBase {
 										if (props.getMotionX() != 0 && props.getMotionY() != 0 && props.getMotionZ() != 0)
 											entity.setMotion(props.getMotionX(), props.getMotionY(), props.getMotionZ());
 									}
-									if(entity instanceof PlayerEntity)
-										((PlayerEntity)entity).removePotionEffect(Effects.SLOWNESS);
+									if (entity instanceof PlayerEntity)
+										((PlayerEntity) entity).removePotionEffect(Effects.SLOWNESS);
 									if (entity instanceof MobEntity)
 										((MobEntity) entity).setNoAI(false);
 									entity.velocityChanged = true;
@@ -294,8 +301,8 @@ public class EntityTheWorld extends EntityStandBase {
 									if (props2.getMotionX() != 0 && props2.getMotionY() != 0 && props2.getMotionZ() != 0)
 										entity.setMotion(props2.getMotionX(), props2.getMotionY(), props2.getMotionZ());
 								}
-								if(entity instanceof PlayerEntity)
-									((PlayerEntity)entity).removePotionEffect(Effects.SLOWNESS);
+								if (entity instanceof PlayerEntity)
+									((PlayerEntity) entity).removePotionEffect(Effects.SLOWNESS);
 								if (entity instanceof MobEntity)
 									((MobEntity) entity).setNoAI(false);
 								entity.setMotion(props2.getMotionX(), props2.getMotionY(), props2.getMotionZ());

--- a/src/main/java/com/novarch/jojomod/network/message/client/CSyncStandAbilitiesPacket.java
+++ b/src/main/java/com/novarch/jojomod/network/message/client/CSyncStandAbilitiesPacket.java
@@ -142,9 +142,8 @@ public class CSyncStandAbilitiesPacket {
                                                             Minecraft.getInstance().getProfiler().endSection();
                                                         }
                                                     }
-                                                }
-//												} else
-//													((EntityTheHand) entity).teleportMaster(((EntityTheHand) entity).getMaster().getEntityId());
+                                                } else
+                                                	((EntityTheHand) entity).teleportMaster(((EntityTheHand) entity).getMaster().getEntityId());
 											});
 									break;
 								}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,2 @@
+public net.minecraft.entity.item.ItemEntity field_70292_b # age
+public net.minecraft.entity.item.minecart.TNTMinecartEntity field_94106_a # minecartTNTFuse


### PR DESCRIPTION
Added an AT for the previously private `ItemEntity#age` and `TNTMinecartEntity#minecartTNTFuse` to improve timestop.